### PR TITLE
Add 'softmax' option for multiclass problems

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -95,6 +95,7 @@ What is supported?
 - Activation functions
     * tanh
     * sigmoid/logistic
+    * softmax normalization on the output layer (with activation identity on output units)
 - Scalers
     * sklearn.preprocessing.StandardScaler
     * sklearn.preprocessing.MinMaxScaler


### PR DESCRIPTION
Hey Vaclav,

I added the 'softmax' option for obtaining multinomial class probabilities (which must sum to one).

The main idea is that softmax is only expected to be added in the final (output) layer and thus, the corresponding activation function to be used by default in PMML in the last layer is 'identity'. [In PMML, 'softmax' is a normalization method ](http://dmg.org/pmml/v4-3/NeuralNetwork.html) and not an activation function.

Sigmoid on output layer:

```python
# output layer
model.add(Dense(..., activation='sigmoid'))
```

leads to

```xml
<NeuralLayer activationFunction="logistic">
```

But softmax on output layer: 

```python
# output layer
model.add(Dense(..., activation='softmax'))
```

leads to

```xml
<NeuralLayer activationFunction="identity" normalizationMethod="softmax">
 ```

in the generated PMML file.