### PR TITLE
Keras 2 version compatibilty quickfix

### DIFF
--- a/examples/cancer.py
+++ b/examples/cancer.py
@@ -2,7 +2,7 @@ from keras2pmml import keras2pmml
 from sklearn.datasets import load_breast_cancer
 import numpy as np
 import theano
-from sklearn.cross_validation import train_test_split
+from sklearn.model_selection import train_test_split
 from keras.utils import np_utils
 from keras.models import Sequential
 from keras.layers.core import Dense

--- a/examples/iris.py
+++ b/examples/iris.py
@@ -2,7 +2,7 @@ from keras2pmml import keras2pmml
 from sklearn.datasets import load_iris
 import numpy as np
 import theano
-from sklearn.cross_validation import train_test_split
+from sklearn.model_selection import train_test_split
 from sklearn.preprocessing import StandardScaler
 from keras.utils import np_utils
 from keras.models import Sequential

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
         'numpy>=1.6.1',
         'SciPy>= 0.9',
         'theano>=0.8.2',
-        'keras>=1.0.6',
+        'keras>=1.0.6, <2.0',
         'scikit-learn>=0.17.1'
     ],
     classifiers=[


### PR DESCRIPTION
Added upper bound to keras version < 2 and updated examples to reflect latest sklearn API.